### PR TITLE
Fix for Issue #8, Width returned as 0 on hidden container element.

### DIFF
--- a/jquery.grid-a-licious.js
+++ b/jquery.grid-a-licious.js
@@ -101,10 +101,18 @@
         },
 
         _setCols: function () {
+            
             // calculate columns
-            this.cols = Math.floor(this.box.width() / this.options.width);
-            diff = (this.box.width() - (this.cols * this.options.width) - this.options.gutter) / this.cols;
-            w = (this.options.width + diff) / this.box.width() * 100;
+            var width = 0;
+            var swappedStyle = this.box.css('display');
+            this.box.css('display', 'block');
+            width = this.box.width();
+            this.box.css('display', swappedStyle);
+
+
+            this.cols = Math.floor(width / this.options.width);
+            diff = (width - (this.cols * this.options.width) - this.options.gutter) / this.cols;
+            w = (this.options.width + diff) / width * 100;
             this.w = w;
             // add columns to box
             for (var i = 0; i < this.cols; i++) {


### PR DESCRIPTION
When the container element was hidden the width would return as 0.
And because width was set to 0 no columns would be added.  This work around sets the 'display' property to 'block',  finds the width, and then replaces the property back to it's original state.
