### PR TITLE
Fix for disappearing grid if col lower than 1

### DIFF
--- a/jquery.grid-a-licious.js
+++ b/jquery.grid-a-licious.js
@@ -103,6 +103,8 @@
         _setCols: function () {
             // calculate columns
             this.cols = Math.floor(this.box.width() / this.options.width);
+            //If Cols lower than 1, the grid disappears
+            if (this.cols < 1) { this.cols = 1; }
             diff = (this.box.width() - (this.cols * this.options.width) - this.options.gutter) / this.cols;
             w = (this.options.width + diff) / this.box.width() * 100;
             this.w = w;


### PR DESCRIPTION
If the document width is smaller than option.width, this.col gets lower than 1, which makes the grid disappear. 

So, I added a check if this.col is lower than 1, make it equal to 1. There may be a more sophisticated solution, but this fixes the problem really quick. ;)
