### PR TITLE
Resize events fired that don't change width won't regrid anymore

### DIFF
--- a/jquery.grid-a-licious.js
+++ b/jquery.grid-a-licious.js
@@ -77,6 +77,7 @@
             this.resetCount = true;
             this.ifCallback = true;
             this.box = this.element;
+            this.boxWidth = this.box.width();
             this.options = $.extend(true, {}, $.Gal.settings, options);
             this.gridArr = $.makeArray(this.box.find(this.options.selector));
             this.isResizing = false;
@@ -325,6 +326,10 @@
         },
 
         resize: function () {
+            if (this.box.width() === this.boxWidth) {
+                return;
+            }
+
             // delete columns in box
             this.box.find($('.galcolumn')).remove();
             // build columns
@@ -335,6 +340,7 @@
             this._renderGrid('append');
             this.ifCallback = true;
             this.isResizing = false;
+            this.boxWidth = this.box.width();
         },
 
         append: function (items) {


### PR DESCRIPTION
It looks like this was also fixed as part of #22 - Chrome for Android will fire a resize event when the url bar is hidden, which causes the grid to redraw.  This fix simply avoids the redraw for resizes that don't actually change the container width.
