### PR TITLE
Better Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "Grid-A-Licious",
+  "version": "3.0.1",
+  "homepage": "https://github.com/suprb/Grid-A-Licious",
+  "authors": [
+    "Andreas Pihlstrom <info@suprb.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.4"
+  }
+}


### PR DESCRIPTION
Added bower.json file. 

My specific use case for this is installing the library from 3rd party build tools that integrate with the Bower API and now because of the bower.json file, can properly detect the dependency on jQuery.
